### PR TITLE
Use replaceState instead of pushState for URLs

### DIFF
--- a/apps/iss_photo_explorer_flat/js/app.js
+++ b/apps/iss_photo_explorer_flat/js/app.js
@@ -190,7 +190,7 @@ function setQueryParam(name, value) {
     params.set(name, value);
 
     url.search = params.toString();
-    window.history.pushState({}, '', url.toString());
+    window.history.replaceState({}, '', url.toString());
 }
 
 function getQueryParam(name) {


### PR DESCRIPTION
In reference to this complaint: https://news.ycombinator.com/item?id=23520622

This will update the URL in the browser, but will not cause the back button to get littered with historical updates.