### PR TITLE
apps/iss_photo_explorer_flat: only hide body overflow on main app

### DIFF
--- a/apps/iss_photo_explorer_flat/css/style.css
+++ b/apps/iss_photo_explorer_flat/css/style.css
@@ -5,6 +5,8 @@
 body {
     background-color: #fff;
     font-family: 'Source Code Pro', monospace;
+}
+body.app {
     overflow: hidden;
 }
 .img_fit {

--- a/apps/iss_photo_explorer_flat/index.html
+++ b/apps/iss_photo_explorer_flat/index.html
@@ -16,7 +16,7 @@
     <script type="text/javascript" src="js/pako_inflate.min.js"></script>
     <script type="text/javascript" src="js/app.js"></script>
 </head>
-<body>
+<body class="app">
     <div id="loading_overlay">
         <img alt="" src="img/loading.svg"/>
     </div>


### PR DESCRIPTION
This fixes the about page, which was also being `overflow: hidden`
and therefore couldn't be scrolled to read anything other than the top.